### PR TITLE
Group repos by organization / user name

### DIFF
--- a/src/OptionsGroup.js
+++ b/src/OptionsGroup.js
@@ -2,6 +2,7 @@ import { css, html } from './utils'
 
 export function OptionsGroup({
   name: groupName,
+  settingName,
   options = [],
   onOptionChange = () => null,
 }) {
@@ -38,7 +39,7 @@ export function OptionsGroup({
       >
         ${options.length > 0
           ? options.map(
-              ([name, checked]) => html`
+              ([name, checked, optionName]) => html`
                 <label
                   class=${css`
                     display: flex;
@@ -58,7 +59,9 @@ export function OptionsGroup({
                   <input
                     type="checkbox"
                     checked=${checked}
-                    onClick=${() => onOptionChange(groupName, name, !checked)}
+                    onClick=${() =>
+                      onOptionChange(settingName || groupName, optionName || name, !checked)
+                    }
                   />
                   <span
                     class=${css`

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,53 @@ function App() {
     }
   }, [])
 
+  const options = useMemo(
+    () => {
+      const reviewerOptions = html`
+        <${OptionsGroup}
+          name="Reviewers"
+          onOptionChange=${changeOption}
+          options=${reviewers}
+        />
+      `
+      // Get user / organization grouping of repos
+      const repoByOrgs = [...repos.reduce((orgMap, [name, checked]) => {
+        const [orgName, repoName] = name.split('/')
+        const repoSet = orgMap.get(orgName) || []
+        repoSet.push([repoName, checked, name])
+        orgMap.set(orgName, repoSet)
+
+        return orgMap
+      }, new Map())]
+      const repoOptions = html`
+        <div
+          class=${css`
+            font-size: 0.8rem;
+          `}
+        >
+          Repos:
+          <div
+            class=${css`
+              padding-left: 20px;
+            `}
+          >
+            ${repoByOrgs.map(([orgName, orgRepos]) => html`
+                <${OptionsGroup}
+                  name=${orgName}
+                  settingName="Repos"
+                  onOptionChange=${changeOption}
+                  options=${orgRepos}
+                />
+              `
+            )}
+          </div>
+          </div>
+      `
+
+      return [repoOptions, reviewerOptions]
+    }, [repos, reviewers]
+  )
+
   const groups = useMemo(
     () =>
       GROUPS.reduce(
@@ -155,19 +202,7 @@ function App() {
     <${Layout}
       title="Aragon Pull Requests"
       hasToken=${Boolean(GITHUB_TOKEN)}
-      options=${[
-        ['Repos', repos],
-        ['Reviewers', reviewers],
-      ].map(
-        ([name, options]) =>
-          html`
-            <${OptionsGroup}
-              name=${name}
-              onOptionChange=${changeOption}
-              options=${options}
-            />
-          `
-      )}
+      options=${options}
       columns=${groups.map(
         ([days, emoji, prs]) =>
           html`


### PR DESCRIPTION
Adds a high-level grouping of different users / organizations' repos to track, primarily to decrease the horizontal scrolling needed:

<img width="482" alt="Screen Shot 2020-03-18 at 1 28 22 PM" src="https://user-images.githubusercontent.com/4166642/76960857-96e7dd00-691c-11ea-8ecf-ae5a9c6b4e68.png">


It's a bit of a surgical change with variables getting added haphazardly, since I didn't want to refactor the options logic too much.